### PR TITLE
python2 & python3 compatibility without needing 'builtins' module for python2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,8 +67,8 @@ integer by using parameter bitorder=1:
 
    >>> b1 = Bits(10)
    >>> b2 = Bits([0,1,0,1])
-   >>> b3 = Bits('\x50',size=4)
-   >>> b4 = Bits('\x0a',size=4,bitorder=1)
+   >>> b3 = Bits(b'\x50',size=4)
+   >>> b4 = Bits(b'\x0a',size=4,bitorder=1)
    >>> b1==b2==b3==b4
    True
 

--- a/crysp/bits.py
+++ b/crysp/bits.py
@@ -4,7 +4,6 @@
 
 import struct
 import codecs
-from builtins import bytes as newbytes
 
 try:
     IntType = (int,long)
@@ -21,7 +20,7 @@ def pack(obj,fmt='<L'):
     assert fmt in ['<L','>L']
     s = [x.ival&0xff for x in obj.split(8)]
     if fmt=='>L': s.reverse()
-    return newbytes(s)
+    return struct.pack('%dB'%len(s), *s)
 
 # generalize struct.unpack to return one int value of
 # arbitrary bit length.
@@ -95,12 +94,15 @@ class Bits(object):
         self.ival = (self.ival<<1)|(x&1)
     elif isinstance(v,bytes):
       self.load(v,bitorder)
+    elif isinstance(v,str):
+      # We are using python3, because 'str' and 'bytes' are different
+      self.load(v.encode(),bitorder)
     else:
         raise TypeError(v)
     if size!=None: self.size = size
 
   def load(self,v,bitorder=-1):
-    bytestr = newbytes(v)
+    bytestr = struct.unpack('%dB'%len(v), v)
     self.size = len(bytestr)*8
     if bitorder==-1:
       l = [reverse_byte(c) for c in bytestr]
@@ -165,7 +167,7 @@ class Bits(object):
       s.append(reverse_byte(v&0xff))
       v = v>>8
       i += 8
-    return newbytes(s)
+    return struct.pack('%dB'%len(s), *s)
 
   def bytes(self):
     return self.__bytes__()

--- a/crysp/bits.py
+++ b/crysp/bits.py
@@ -94,9 +94,6 @@ class Bits(object):
         self.ival = (self.ival<<1)|(x&1)
     elif isinstance(v,bytes):
       self.load(v,bitorder)
-    elif isinstance(v,str):
-      # We are using python3, because 'str' and 'bytes' are different
-      self.load(v.encode(),bitorder)
     else:
         raise TypeError(v)
     if size!=None: self.size = size

--- a/crysp/crc.py
+++ b/crysp/crc.py
@@ -45,7 +45,8 @@ def crc(data,table,Xinit=0,Xfinal=None):
     print("crc: bytes input required")
     return None
   r = Bits(Xinit,table[0].size)
-  for b in newbytes(data):
+  data = struct.unpack("%dB"%len(data), data)
+  for b in data:
     p = table[(r.ival^b)&0xff]
     r = (r>>8)^p
   if Xfinal:
@@ -56,7 +57,7 @@ def crc_back_pos(data,pos,table,Xfinal,c):
   if not isinstance(data,bytes):
     print("crc: bytes input required")
     return None
-  data = newbytes(data)
+  data = struct.unpack("%dB"%len(data), data)
   if not (0<=pos<len(data)):
     print("crc_back: pos error")
     return None

--- a/crysp/crc.py
+++ b/crysp/crc.py
@@ -45,8 +45,7 @@ def crc(data,table,Xinit=0,Xfinal=None):
     print("crc: bytes input required")
     return None
   r = Bits(Xinit,table[0].size)
-  data = struct.unpack("%dB"%len(data), data)
-  for b in data:
+  for b in struct.unpack("%dB"%len(data), data):
     p = table[(r.ival^b)&0xff]
     r = (r>>8)^p
   if Xfinal:

--- a/crysp/keccak.py
+++ b/crysp/keccak.py
@@ -101,7 +101,7 @@ class Keccak(object):
             needed = bitlen
             if not self.duplexing:
                 b = Bits(M[-1:],size=needed%8)[::-1]
-                M = M[:needed//8]+newbytes([b.ival])
+                M = M[:needed//8]+struct.pack("B", b.ival)
         r = self.r
         br,rr = divmod(r,8)
         P = BytesIO(M)

--- a/crysp/mode.py
+++ b/crysp/mode.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
-from builtins import bytes as newbytes
 
 # This code is part of crysp
 # Copyright (C) 2013 Axel Tillequin (bdcht3@gmail.com) 
@@ -33,9 +32,9 @@ class Mode(object):
 
     # xor input byte strings (over min length):
     def xorstr(self,a,b):
-        a = newbytes(a)
-        b = newbytes(b)
-        return newbytes([x^y for (x,y) in zip(a,b)])
+        a = struct.unpack("%dB"%len(a), a)
+        b = struct.unpack("%dB"%len(b), b)
+        return struct.pack("%dB"%min(len(a),len(b)), *[x^y for (x,y) in zip(a,b)])
 
 # -----------------------------------------------------------------------------
 # Electronic Code Book, default padding is pkcs7
@@ -278,7 +277,7 @@ class Chain(object):
 
     # xor input byte strings (over min length):
     def xorstr(self,a,b):
-        a = newbytes(a)
-        b = newbytes(b)
-        return newbytes([x^y for (x,y) in zip(a,b)])
+        a = struct.unpack("%dB"%len(a), a)
+        b = struct.unpack("%dB"%len(b), b)
+        return struct.pack("%dB"%min(len(a),len(b)), *[x^y for (x,y) in zip(a,b)])
 

--- a/crysp/padding.py
+++ b/crysp/padding.py
@@ -6,7 +6,6 @@
 
 from crysp.bits import *
 from io import BytesIO
-from builtins import bytes as newbytes
 import pdb
 
 class PaddingError(Exception):
@@ -129,11 +128,11 @@ class pkcs7(blockiterator):
         q = (self.blocklen-p) or self.blocklen
         if q==0: q=self.blocklen
         self.padcnt = q*8
-        return m+(newbytes([q])*q)
+        return m+(struct.pack("B",q)*q)
     # remove padding:
     def remove(self,c):
-        q = c[-1]
-        if q>self.blocklen or (c[-q:]!=newbytes([q])*q):
+        q = ord(c[-1:])
+        if q>self.blocklen or (c[-q:]!=struct.pack("B",q)*q):
             raise PaddingError(c)
         else:
             return c[:-q]
@@ -147,7 +146,7 @@ class X923(blockiterator):
         p = len(m)
         q = (self.blocklen-p) or self.blocklen
         r = m+(b'\0'*(q-1))
-        r += newbytes([q])
+        r += struct.pack("B",q)
         self.padflag = True
         self.bitcnt += p*8
         self.padcnt  = q*8

--- a/crysp/poly.py
+++ b/crysp/poly.py
@@ -20,7 +20,7 @@ class Poly(object):
           self.ival = [int(x)&mask for x in v]
       elif isinstance(v,bytes):
           mask = 0xff
-          self.ival = list(newbytes(v))
+          self.ival = list(struct.unpack("%dB"%len(v), v))
       else:
           raise TypeError
       self.mask = mask

--- a/crysp/skein.py
+++ b/crysp/skein.py
@@ -28,7 +28,7 @@ class Skein(object):
         self.Yl = Yl
         self.Yf = Yf
         self.Ym = Ym
-        self.C += newbytes([Yl,Yf,Ym])+b'\0'*13
+        self.C += struct.pack("BBB", Yl,Yf,Ym)+b'\0'*13
         self.key = key
         self.prs = prs
         self.PK  = PK

--- a/tests/test_chacha.py
+++ b/tests/test_chacha.py
@@ -87,7 +87,8 @@ def test_chacha_002():
 # -------------------------------------------------------------------
 
 def tobits(s):
-    x = newbytes([int(x,16) for x in s.split()])
+    s = s.split()
+    x = struct.pack("%dB"%len(s), *[int(x,16) for x in s])
     return Bits(x,bitorder=1)
 
 def test_chacha_003():

--- a/tests/test_padding.py
+++ b/tests/test_padding.py
@@ -124,7 +124,7 @@ def test_bitpadding_003():
     assert pad.padflag
     assert pad.bitcnt==63
     assert pad.padcnt == 1
-    assert pad.remove(b)[-1]&0xfe == ord(b'A')&0xfe
+    assert ord(pad.remove(b)[-1:])&0xfe == ord(b'A')&0xfe
 
 def test_pkcs7_001():
     pad = pkcs7(64)

--- a/tests/test_salsa20.py
+++ b/tests/test_salsa20.py
@@ -3,31 +3,33 @@ import pytest
 from crysp.salsa20 import *
 
 L = [211, 159, 13, 115, 76, 55, 82, 183, 3, 117, 222, 37, 191, 187, 234, 136, 49, 237, 179, 48, 1, 106, 178, 219, 175, 199, 166, 48, 86, 16, 179, 207, 31, 240, 32, 63, 15, 83, 93, 161, 116, 147, 48, 113, 238, 55, 204, 36, 79, 201, 235, 79, 3, 81, 156, 47, 203, 26, 244, 243, 88, 118, 104, 54]
-m = newbytes(L)
+m = struct.pack("%dB"%len(L), *L)
 
 k0 = list(range(1,17))
-k1 = list(range(201,217))
+k1 = k0 + list(range(201,217))
 n  = list(range(101,117))
-v  = Bits(newbytes(n),bitorder=1)
+v  = Bits(struct.pack("%dB"%len(n), *n),bitorder=1)
 
 def test_salsa20_000_hash():
     r = Salsa20().hash(m)
-    rl = list(newbytes(r))
+    rl = list(struct.unpack("%dB"%len(r), r))
     assert rl[0:3] == [109,42,178]
     assert rl[-3:] == [19,48,202]
 
 def test_salsa20_001_cipher():
-    K = Bits(newbytes(k0+k1),bitorder=1)
+    K = Bits(struct.pack("%dB"%len(k1),*k1),bitorder=1)
     S = Salsa20(K)
     S.p[6:10] = v.split(32)
-    res = list(newbytes(pack(S.core(S.p))))
+    res = pack(S.core(S.p))
+    res = list(struct.unpack("%dB"%len(res), res))
     assert res[0:5] == [69,37,68,39,41]
     assert res[-5:] == [236,234,103,246,74]
 
 def test_salsa20_002_cipher():
-    K = Bits(newbytes(k0),bitorder=1)
+    K = Bits(struct.pack("%dB"%len(k0),*k0),bitorder=1)
     S = Salsa20(K)
     S.p[6:10] = v.split(32)
-    res = list(newbytes(pack(S.core(S.p))))
+    res = pack(S.core(S.p))
+    res = list(struct.unpack("%dB"%len(res), res))
     assert res[0:5] == [39,173,46,248,30]
     assert res[-5:] == [181,104,182,177,193]


### PR DESCRIPTION
Because `import builtins` fails on default installs of python2, and it is not necessary to deal with the fact that `bytes` is different from python2 to python3.